### PR TITLE
Fix iframe video cerati mobile

### DIFF
--- a/index.css
+++ b/index.css
@@ -141,8 +141,8 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 100%;
-    height: 100%;
+    width: 75%;
+    height: 75%;
 }
 
 /* En pantallas grandes (≥769px), cambia a 16:9 pero sin exceder la sección */


### PR DESCRIPTION
se arregló el tamaño del iframe en versión mobile, ya que excedía el tamaño de su sección